### PR TITLE
fix/#27/kakao-login

### DIFF
--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -6,7 +6,9 @@ import { Footer } from "../../components/Footer";
 // 로그인/회원가입 페이지
 export default function Login() {
   const REST_API_KEY = "4d9aacde53f8f2b4edd1d27d4ddf98e9";
-  const REDIRECT_URI = "http://localhost:3000/callback";
+  const REDIRECT_URI = "https://remini.vercel.app/callback";
+  // 로컬 개발할 때는 http://localhost:3000/callback 잠깐 바꿔서 개발하다가
+  // PR 올릴 때는 : https://remini.vercel.app/callback로 다시 교체하면 될 것 같습니다👍
 
   const kakaoOAuthLink = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
 

--- a/src/pages/login/logingCallback.tsx
+++ b/src/pages/login/logingCallback.tsx
@@ -12,7 +12,7 @@ function LogingCallback() {
       const urlParams = new URLSearchParams(window.location.search);
       const code = urlParams.get("code");
 
-      console.log("code", code);
+      console.log(code);
 
       if (code) {
         sendCodeToServer(code);
@@ -24,11 +24,8 @@ function LogingCallback() {
     try {
       const response = await axios.post(
         "http://www.remini.store/api/auth/kakao",
-        {},
         {
-          headers: {
-            Authorization: `${code}`,
-          },
+          authorizationCode: code,
         }
       );
       console.log("response", response);
@@ -38,7 +35,7 @@ function LogingCallback() {
       localStorage.setItem("accessToken", accessToken);
 
       // 로그인 처리 완료 후 Home 페이지로 리디렉트
-      navigate("/home");
+      navigate("/");
     } catch (error) {
       console.error("Error sending code to server:", error);
     }


### PR DESCRIPTION
- 인가코드를 헤더에서 본문(body)으로 옮겨서 에러 해결
- 배포, PR 올릴 때는 REDIRECT_URI = "https://remini.vercel.app/callback"; 이렇게 하고
- 로컬에서 개발할 때는 http://localhost:3000/callback로 바꿔서 개발하면 될 것 같습니다.